### PR TITLE
ProblemDetails - Configuration same as defaults

### DIFF
--- a/src/DotNetBestPractices.Api/Configuration.cs
+++ b/src/DotNetBestPractices.Api/Configuration.cs
@@ -18,7 +18,7 @@ namespace DotNetBestPractices.Api
 
             return services
                 .AddCustomMvc()
-                .AddCustomProblemDetails(environment)
+                .AddProblemDetails()
                 .AddCustomOptions(config);
         }
 

--- a/src/DotNetBestPractices.Api/Extensions/ServicesCollectionExtensions.cs
+++ b/src/DotNetBestPractices.Api/Extensions/ServicesCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
-using Hellang.Middleware.ProblemDetails;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -22,15 +21,5 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return services.Configure<MultimediaServiceOptions>(pConfiguration.GetSection(nameof(MultimediaServiceOptions)));
         }
-
-        public static IServiceCollection AddCustomProblemDetails(this IServiceCollection services, IWebHostEnvironment environment)
-        {
-            return services
-                .AddProblemDetails(configure =>
-                {
-                    configure.IncludeExceptionDetails = _ => environment.EnvironmentName == "Development";
-                });
-        }
-        
     }
 }


### PR DESCRIPTION
Hi @gmquiroga! 👋 

Just stumbled over this repo and saw you've configured the ProblemDetails middleware to include exception details when the environment name is `Development`. 

I thought I'd just let you know that [this is the default](https://github.com/khellang/Middleware/blob/36afb2a722d54fce0652422e9c70000291160cd5/src/ProblemDetails/ProblemDetailsOptionsSetup.cs#L46-L49) and thus isn't needed in the configuration. Also, there's a nice convenience extension method for it, called `IsDevelopment` 😄 